### PR TITLE
Fix/user api 버그 수정

### DIFF
--- a/src/main/java/com/mattaeng/mattaengapi/controller/UserController.java
+++ b/src/main/java/com/mattaeng/mattaengapi/controller/UserController.java
@@ -68,7 +68,7 @@ public class UserController {
 	@PutMapping("/password")
 	public Api<UserInfoResponse> updateUserPassword(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
-		@RequestBody UpdateUserPasswordRequest updateUserPasswordRequest
+		@Valid @RequestBody UpdateUserPasswordRequest updateUserPasswordRequest
 	) {
 		return Api.ok(userService.updateUserPassword(userDetails, updateUserPasswordRequest));
 	}

--- a/src/main/java/com/mattaeng/mattaengapi/dto/user/UpdateUserPasswordRequest.java
+++ b/src/main/java/com/mattaeng/mattaengapi/dto/user/UpdateUserPasswordRequest.java
@@ -5,7 +5,6 @@ import com.mattaeng.mattaengapi.common.annotations.Password.Password;
 import jakarta.validation.constraints.NotBlank;
 
 public record UpdateUserPasswordRequest(
-	@Password
 	String oldPassword,
 
 	@Password

--- a/src/main/java/com/mattaeng/mattaengapi/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mattaeng/mattaengapi/security/jwt/JwtAuthenticationFilter.java
@@ -43,7 +43,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 		final String SWAGGER_ENDPOINT = "/swagger-ui";
 		final String API_DOCS_ENDPOINT = "/v3/api-docs";
-		final String LOGIN_ENDPOINT = "/api/v1/login";
+		final String LOGIN_ENDPOINT = "/api/v1/auth/login";
 		final String SIGNUP_ENDPOINT = "/api/v1/users";
 
 		return (uri.startsWith(SWAGGER_ENDPOINT) && method.equals(GET_METHOD)) ||


### PR DESCRIPTION
## 📝작업 내용
- /oauth/login 엔드포인트를 jwt 필터 예외로 등록
- 비밀번호 변경 API에 `@`Valid 적용
- 비밀번호 변경 API 요청 시, oldPassword에 `@`Password 제거
  - oldPassword는 현재 비밀번호와 일치하는 지 체크하기 때문에 필요없음